### PR TITLE
Update vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig(({ mode }) => {
 			'import.meta.env.STORYBLOK_DELIVERY_API_TOKEN': JSON.stringify(
 				env.STORYBLOK_DELIVERY_API_TOKEN,
 			),
+			'import.meta.env.STORYBLOK_REGION': JSON.stringify(env.STORYBLOK_REGION),
 			'import.meta.env.STORYBLOK_API_BASE_URL': JSON.stringify(
 				env.STORYBLOK_API_BASE_URL,
 			),


### PR DESCRIPTION
This PR adds the missing `STORYBLOK_REGION` environment variable to the React template.

The region configuration is required for Storyblok spaces hosted outside the EU. Without it, the generated project cannot connect to non-EU spaces out of the box.

## Changes

* Add the `STORYBLOK_REGION` environment variable to the React template.
* Pass the variable through the Vite configuration so it is available without requiring the `VITE_` prefix, matching the behavior of our other templates.
